### PR TITLE
Support unique event payloads

### DIFF
--- a/packages/ichi/cmd/home.html
+++ b/packages/ichi/cmd/home.html
@@ -35,12 +35,32 @@
 
           const playerId = getPlayerId();
 
+          const event = {};
+          switch (action) {
+            case 1:
+              event.leave = {};
+              break;
+            case 2:
+              event.start = {};
+              break;
+            case 3:
+              event.end = {};
+              break;
+            case 4:
+              event.playcard = {};
+              event.card = {
+                face: 0,
+                color: 0,
+              };
+              break;
+            default:
+              return false;
+          }
+
           conn.send(JSON.stringify({
             playerId,
             timestamp: new Date().getTime(),
-            payload: {
-              action,
-            }
+            event,
           }));
 
           return false;
@@ -120,9 +140,10 @@
   <body>
     <div id="log"></div>
     <form id="form">
-      <button type="submit" id="action" value="2">Start</button>
-      <button type="submit" id="action" value="4">Play</button>
-      <button type="submit" id="action" value="3">End</button>
+      <button type="submit" id="action" value="1">Leave Game</button>
+      <button type="submit" id="action" value="2">Start Game</button>
+      <button type="submit" id="action" value="4">Play Card</button>
+      <button type="submit" id="action" value="3">End Game</button>
     </form>
   </body>
 </html>

--- a/packages/ichi/internal/drei.go
+++ b/packages/ichi/internal/drei.go
@@ -16,6 +16,20 @@ const (
 	Seven
 )
 
+var cardFaceNames = map[CardFace]string{
+	One:   "One",
+	Two:   "Two",
+	Three: "Three",
+	Four:  "Four",
+	Five:  "Five",
+	Six:   "Six",
+	Seven: "Seven",
+}
+
+func (cf CardFace) String() string {
+	return cardFaceNames[cf]
+}
+
 var NumberFaces = []CardFace{One, Two, Three, Four, Five, Six, Seven}
 //var SpecialFaces = []CardFace{Skip, Reverse, DrawTwo, Wild, WildDrawFour}
 
@@ -29,19 +43,34 @@ const (
 	White
 )
 
-var CardColors = []Color{Red, Yellow, Blue, Black, White}
+var colorNames = map[Color]string{
+	Red:    "Red",
+	Yellow: "Yellow",
+	Blue:   "Blue",
+	Black:  "Black",
+	White:  "White",
+}
 
+func (c Color) String() string {
+	return colorNames[c]
+}
+
+var CardColors = []Color{Red, Yellow, Blue, Black, White}
 
 type Card struct {
 	Face  CardFace
 	Color Color
 }
 
+func (c Card) String() string {
+	return c.Color.String() + " " + c.Face.String()
+}
+
 func Compare(c1, c2 Card) bool {
 	return c1.Face == c2.Face || c1.Color == c2.Color
 }
 
-func NewDeck () []Card {
+func NewDeck() []Card {
 	deck := make([]Card, 0)
 	for color := 0; color < len(CardColors); color++ {
 		for face := 0; face < len(NumberFaces); face++ {

--- a/packages/ichi/internal/game_machine.go
+++ b/packages/ichi/internal/game_machine.go
@@ -131,13 +131,13 @@ func HandlePlayerAction(game *Game, message Message) {
 			activePlayerIndex := 0
 			for i, playerId := range game.playerOrder {
 				if playerId == game.activePlayer.id {
-					activePlayerIndex = i
+					activePlayerIndex = (i + 1) % len(game.playerOrder)
 					break
 				}
 			}
 
-			activePlayerIndex = (activePlayerIndex + 1) % len(game.playerOrder)
 			game.activePlayer = game.players[game.playerOrder[activePlayerIndex]]
+
 			fmt.Printf("Action:\t\t%s\nPlayer Id:\t%s\nCard Played:\t%s\n", message.Event.PlayCard.Action(), message.PlayerId, message.Event.PlayCard.Card)
 		} else {
 			fmt.Printf("Action:\t\t%s\nPlayer Id:\t%s\nCard Played:\tPlayed out of turn\n", message.Event.PlayCard.Action(), message.PlayerId)

--- a/packages/ichi/internal/types.go
+++ b/packages/ichi/internal/types.go
@@ -1,40 +1,46 @@
 package api
 
-import "log"
-
 type Message struct {
 	PlayerId string
 
 	Timestamp int
 
-	Event Event
+	Event EventUnion
+}
+
+type EventUnion struct {
+	Join *JoinEvent
+	Leave *LeaveEvent
+	Start *StartEvent
+	End *EndEvent
+	PlayCard *PlayCardEvent
+	DrawCard *DrawCardEvent
 }
 
 type Event interface {
-	IsEvent()
+	Action() GameAction
 }
 
-type EmptyEvent struct {
-	Action GameAction
+type JoinEvent struct {}
+func (JoinEvent) Action() GameAction { return Join }
+
+type LeaveEvent struct {}
+func (LeaveEvent) Action() GameAction { return Leave }
+
+type StartEvent struct {}
+func (StartEvent) Action() GameAction { return Start }
+
+type EndEvent struct {}
+func (EndEvent) Action() GameAction { return End }
+
+type PlayCardEvent struct {
+	Card Card
+	TargetPlayer *string
 }
+func (PlayCardEvent) Action() GameAction { return PlayCard }
 
-type CardEvent struct {
-	Action GameAction
-	PlayedCard Card
-}
-
-func (EmptyEvent) IsEvent() {}
-func (CardEvent) IsEvent() {}
-
-func HandleEvent(ev Event) {
-	switch evt := ev.(type) {
-	case CardEvent:
-		log.Println("PlayCardEvent", evt.PlayedCard)
-	default:
-		log.Println("Default")
-	}
-}
-
+type DrawCardEvent struct {}
+func (DrawCardEvent) Action() GameAction { return DrawCard }
 
 type GameAction int
 
@@ -47,6 +53,19 @@ const (
 	DrawCard
 )
 
+var gameActionName = map[GameAction]string{
+	Join:     "Join",
+	Leave:    "Leave",
+	Start:    "Start",
+	End:      "End",
+	PlayCard: "PlayCard",
+	DrawCard: "DrawCard",
+}
+
+func (ga GameAction) String() string {
+	return gameActionName[ga]
+}
+
 type PlayerRole int
 
 const (
@@ -54,6 +73,16 @@ const (
 	Participant
 	Audience
 )
+
+var playerRoleName = map[PlayerRole]string{
+	Host:        "Host",
+	Participant: "Participant",
+	Audience:    "Audience",
+}
+
+func (pr PlayerRole) String() string {
+	return playerRoleName[pr]
+}
 
 type User struct {
 	id string
@@ -94,6 +123,16 @@ const (
 	Playing
 	Ended
 )
+
+var gameStateName = map[GameState]string{
+	Waiting: "Waiting",
+	Playing: "Playing",
+	Ended:   "Ended",
+}
+
+func (gs GameState) String() string {
+	return gameStateName[gs]
+}
 
 type ClientState struct {
 	Players []Player


### PR DESCRIPTION
Rather than attempting to combine all payload types into a single object, each GameAction is now associated with a unique struct which can define its own payload. All event structs are combined into a single EventUnion struct on the Event field of the Message. Making each field type a pointer effectively makes them optional types; this means on the frontend we need only send the field we want in our payload and on the backend we can simply update the switch statement to match on non-null cases.

Additionally, I have made all of the existing enums implement the `String()` interface and added a bit of polish to the log outputs, as well as resolved a couple breakages I ran into along the way.